### PR TITLE
Add simple ecommerce web demo

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,19 @@
-# finalyear
+# Pink Boutique
+
+A simple e-commerce demo for a women's clothing store with light pink and white aesthetic. Built with Node.js, Express and SQLite. Includes basic catalog, cart, checkout and user authentication. Blockchain audit hooks are placed at key actions (`signup`, `product_add`, `product_edit`, `product_delete`, `purchase`).
+
+## Setup
+
+Install dependencies and run the server:
+
+```bash
+npm install
+npm start
+```
+
+The server listens on port 3000.
+
+## Blockchain Logging
+
+The function `auditLog(action, details)` in `server.js` is called whenever important actions occur. Replace its contents with calls to your blockchain backend to record immutable logs.
+

--- a/package.json
+++ b/package.json
@@ -1,0 +1,23 @@
+{
+  "name": "finalyear",
+  "version": "1.0.0",
+  "description": "",
+  "main": "index.js",
+  "scripts": {
+    "start": "node server.js",
+    "dev": "nodemon server.js",
+    "test": "echo \"No tests\""
+  },
+  "keywords": [],
+  "author": "",
+  "license": "ISC",
+  "type": "commonjs",
+  "dependencies": {
+    "express": "^4.18.2",
+    "ejs": "^3.1.9",
+    "sqlite3": "^5.1.6",
+    "bcryptjs": "^2.4.3",
+    "express-session": "^1.17.3",
+    "connect-flash": "^0.1.1"
+  }
+}

--- a/public/style.css
+++ b/public/style.css
@@ -1,0 +1,8 @@
+body { font-family: 'Montserrat', sans-serif; background: #fff; color: #333; margin:0; }
+header { background:#ffe6f2; padding:10px; display:flex; justify-content:space-between; align-items:center; }
+header a { margin:0 5px; color:#d63384; text-decoration:none; }
+.banner { background:#ffd6e7; padding:40px; text-align:center; }
+.products { display:flex; flex-wrap:wrap; gap:20px; padding:20px; }
+.product { border:1px solid #f8c1d8; padding:10px; width:200px; text-align:center; background:#fff; transition:transform .2s; }
+.product:hover { transform:scale(1.05); }
+.error { color:red; }

--- a/server.js
+++ b/server.js
@@ -1,0 +1,207 @@
+const express = require('express');
+const session = require('express-session');
+const flash = require('connect-flash');
+const bcrypt = require('bcryptjs');
+const sqlite3 = require('sqlite3').verbose();
+const path = require('path');
+
+const app = express();
+const db = new sqlite3.Database('store.db');
+
+function auditLog(action, details) {
+  // Placeholder for blockchain logging
+  console.log('AUDIT', action, details);
+}
+
+app.set('view engine', 'ejs');
+app.use(express.urlencoded({ extended: true }));
+app.use(session({ secret: 'secret', resave: false, saveUninitialized: false }));
+app.use(flash());
+app.use(express.static(path.join(__dirname, 'public')));
+
+app.use((req, res, next) => {
+  res.locals.currentUser = req.session.user;
+  res.locals.flash = req.flash();
+  next();
+});
+
+// Database setup
+
+db.serialize(() => {
+  db.run(`CREATE TABLE IF NOT EXISTS users(
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    email TEXT UNIQUE,
+    password TEXT,
+    isAdmin INTEGER DEFAULT 0
+  )`);
+  db.run(`CREATE TABLE IF NOT EXISTS products(
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    name TEXT,
+    description TEXT,
+    price REAL,
+    image TEXT
+  )`);
+  db.run(`CREATE TABLE IF NOT EXISTS orders(
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    userId INTEGER,
+    total REAL,
+    items TEXT,
+    createdAt DATETIME DEFAULT CURRENT_TIMESTAMP
+  )`);
+});
+
+// Middleware to check if user is authenticated
+function requireAuth(req, res, next) {
+  if (!req.session.user) return res.redirect('/login');
+  next();
+}
+
+function requireAdmin(req, res, next) {
+  if (!req.session.user || !req.session.user.isAdmin) return res.redirect('/');
+  next();
+}
+
+// Routes
+app.get('/', (req, res) => {
+  db.all('SELECT * FROM products LIMIT 4', (err, products) => {
+    res.render('index', { products });
+  });
+});
+
+app.get('/products', (req, res) => {
+  db.all('SELECT * FROM products', (err, products) => {
+    res.render('products', { products });
+  });
+});
+
+app.get('/product/:id', (req, res) => {
+  db.get('SELECT * FROM products WHERE id=?', req.params.id, (err, product) => {
+    if (!product) return res.redirect('/products');
+    res.render('product', { product });
+  });
+});
+
+app.post('/cart/add/:id', (req, res) => {
+  const id = req.params.id;
+  db.get('SELECT * FROM products WHERE id=?', id, (err, product) => {
+    if (!product) return res.redirect('/products');
+    if (!req.session.cart) req.session.cart = [];
+    req.session.cart.push(product);
+    res.redirect('/cart');
+  });
+});
+
+app.get('/cart', (req, res) => {
+  const cart = req.session.cart || [];
+  const total = cart.reduce((s, p) => s + p.price, 0);
+  res.render('cart', { cart, total });
+});
+
+app.post('/cart/remove/:index', (req, res) => {
+  const i = parseInt(req.params.index);
+  if (req.session.cart && req.session.cart[i]) {
+    req.session.cart.splice(i, 1);
+  }
+  res.redirect('/cart');
+});
+
+app.post('/checkout', requireAuth, (req, res) => {
+  const cart = req.session.cart || [];
+  if (!cart.length) return res.redirect('/cart');
+  const total = cart.reduce((s, p) => s + p.price, 0);
+  const items = JSON.stringify(cart);
+  db.run('INSERT INTO orders(userId,total,items) VALUES(?,?,?)', [req.session.user.id, total, items], function(err) {
+    if (err) return res.redirect('/cart');
+    req.session.cart = [];
+    auditLog('purchase', { user: req.session.user.id, orderId: this.lastID });
+    res.render('confirm', { orderId: this.lastID });
+  });
+});
+
+app.get('/orders', requireAuth, (req, res) => {
+  db.all('SELECT * FROM orders WHERE userId=?', req.session.user.id, (err, orders) => {
+    res.render('orders', { orders });
+  });
+});
+
+app.get('/signup', (req, res) => {
+  res.render('signup');
+});
+
+app.post('/signup', (req, res) => {
+  const { email, password } = req.body;
+  const hash = bcrypt.hashSync(password, 10);
+  db.run('INSERT INTO users(email,password) VALUES(?,?)', [email, hash], function(err) {
+    if (err) {
+      req.flash('error', 'Email already used');
+      return res.redirect('/signup');
+    }
+    auditLog('signup', { userId: this.lastID });
+    req.session.user = { id: this.lastID, email };
+    res.redirect('/');
+  });
+});
+
+app.get('/login', (req, res) => {
+  res.render('login');
+});
+
+app.post('/login', (req, res) => {
+  const { email, password } = req.body;
+  db.get('SELECT * FROM users WHERE email=?', email, (err, user) => {
+    if (!user || !bcrypt.compareSync(password, user.password)) {
+      req.flash('error', 'Invalid credentials');
+      return res.redirect('/login');
+    }
+    req.session.user = { id: user.id, email: user.email, isAdmin: user.isAdmin };
+    res.redirect('/');
+  });
+});
+
+app.get('/logout', (req, res) => {
+  req.session.destroy(() => {
+    res.redirect('/');
+  });
+});
+
+// Admin routes
+app.get('/admin/products', requireAdmin, (req, res) => {
+  db.all('SELECT * FROM products', (err, products) => {
+    res.render('admin_products', { products });
+  });
+});
+
+app.get('/admin/products/new', requireAdmin, (req, res) => {
+  res.render('product_form', { product: {} });
+});
+
+app.get('/admin/products/edit/:id', requireAdmin, (req, res) => {
+  db.get('SELECT * FROM products WHERE id=?', req.params.id, (err, product) => {
+    res.render('product_form', { product });
+  });
+});
+
+app.post('/admin/products/save', requireAdmin, (req, res) => {
+  const { id, name, description, price, image } = req.body;
+  if (id) {
+    db.run('UPDATE products SET name=?, description=?, price=?, image=? WHERE id=?', [name, description, price, image, id], err => {
+      auditLog('product_edit', { id });
+      res.redirect('/admin/products');
+    });
+  } else {
+    db.run('INSERT INTO products(name,description,price,image) VALUES(?,?,?,?)', [name, description, price, image], function(err){
+      auditLog('product_add', { id: this.lastID });
+      res.redirect('/admin/products');
+    });
+  }
+});
+
+app.post('/admin/products/delete/:id', requireAdmin, (req, res) => {
+  db.run('DELETE FROM products WHERE id=?', req.params.id, err => {
+    auditLog('product_delete', { id: req.params.id });
+    res.redirect('/admin/products');
+  });
+});
+
+const PORT = process.env.PORT || 3000;
+app.listen(PORT, () => console.log(`Server running on port ${PORT}`));

--- a/views/admin_products.ejs
+++ b/views/admin_products.ejs
@@ -1,0 +1,27 @@
+<!DOCTYPE html>
+<html>
+<head>
+  <title>Admin - Products</title>
+  <link rel="stylesheet" href="/style.css">
+</head>
+<body>
+  <%- include('partials/header'); %>
+  <h2>Manage Products</h2>
+  <a href="/admin/products/new">Add Product</a>
+  <table>
+    <tr><th>Name</th><th>Price</th><th>Actions</th></tr>
+    <% products.forEach(p => { %>
+    <tr>
+      <td><%= p.name %></td>
+      <td>$<%= p.price %></td>
+      <td>
+        <a href="/admin/products/edit/<%= p.id %>">Edit</a>
+        <form method="post" action="/admin/products/delete/<%= p.id %>" style="display:inline;">
+          <button type="submit">Delete</button>
+        </form>
+      </td>
+    </tr>
+    <% }) %>
+  </table>
+</body>
+</html>

--- a/views/cart.ejs
+++ b/views/cart.ejs
@@ -1,0 +1,28 @@
+<!DOCTYPE html>
+<html>
+<head>
+  <title>Your Cart - Pink Boutique</title>
+  <link rel="stylesheet" href="/style.css">
+</head>
+<body>
+  <%- include('partials/header'); %>
+  <h2>Your Cart</h2>
+  <% if (!cart.length) { %>
+    <p>Your cart is empty.</p>
+  <% } else { %>
+    <ul>
+      <% cart.forEach((item, i) => { %>
+        <li><%= item.name %> - $<%= item.price %>
+          <form method="post" action="/cart/remove/<%= i %>" style="display:inline;">
+            <button type="submit">Remove</button>
+          </form>
+        </li>
+      <% }) %>
+    </ul>
+    <p>Total: $<%= total %></p>
+    <form method="post" action="/checkout">
+      <button type="submit">Checkout</button>
+    </form>
+  <% } %>
+</body>
+</html>

--- a/views/confirm.ejs
+++ b/views/confirm.ejs
@@ -1,0 +1,12 @@
+<!DOCTYPE html>
+<html>
+<head>
+  <title>Order Confirmation</title>
+  <link rel="stylesheet" href="/style.css">
+</head>
+<body>
+  <%- include('partials/header'); %>
+  <h2>Thank you for your purchase!</h2>
+  <p>Your order ID is <%= orderId %>.</p>
+</body>
+</html>

--- a/views/index.ejs
+++ b/views/index.ejs
@@ -1,0 +1,38 @@
+<!DOCTYPE html>
+<html>
+<head>
+  <title>Pink Boutique</title>
+  <link rel="stylesheet" href="/style.css">
+</head>
+<body>
+  <header>
+    <h1>Pink Boutique</h1>
+    <nav>
+      <% if (currentUser) { %>
+        <a href="/logout">Logout</a>
+        <a href="/orders">My Orders</a>
+        <% if (currentUser.isAdmin) { %>
+        <a href="/admin/products">Admin</a>
+        <% } %>
+      <% } else { %>
+        <a href="/login">Login</a>
+        <a href="/signup">Signup</a>
+      <% } %>
+      <a href="/cart">Cart (<%= (session.cart || []).length %>)</a>
+    </nav>
+  </header>
+  <section class="banner">
+    <h2>Welcome to our store</h2>
+  </section>
+  <section class="products">
+    <% products.forEach(p => { %>
+      <div class="product">
+        <img src="<%= p.image %>" alt="<%= p.name %>" />
+        <h3><%= p.name %></h3>
+        <p>$<%= p.price %></p>
+        <a href="/product/<%= p.id %>">View</a>
+      </div>
+    <% }) %>
+  </section>
+</body>
+</html>

--- a/views/login.ejs
+++ b/views/login.ejs
@@ -1,0 +1,17 @@
+<!DOCTYPE html>
+<html>
+<head>
+  <title>Login - Pink Boutique</title>
+  <link rel="stylesheet" href="/style.css">
+</head>
+<body>
+  <%- include('partials/header'); %>
+  <h2>Login</h2>
+  <% if (flash.error) { %><p class="error"><%= flash.error %></p><% } %>
+  <form method="post" action="/login">
+    <input type="email" name="email" placeholder="Email" required>
+    <input type="password" name="password" placeholder="Password" required>
+    <button type="submit">Login</button>
+  </form>
+</body>
+</html>

--- a/views/orders.ejs
+++ b/views/orders.ejs
@@ -1,0 +1,20 @@
+<!DOCTYPE html>
+<html>
+<head>
+  <title>My Orders - Pink Boutique</title>
+  <link rel="stylesheet" href="/style.css">
+</head>
+<body>
+  <%- include('partials/header'); %>
+  <h2>My Orders</h2>
+  <% if (!orders.length) { %>
+    <p>No orders yet.</p>
+  <% } else { %>
+    <ul>
+      <% orders.forEach(o => { %>
+        <li>Order #<%= o.id %> - $<%= o.total %> - <%= o.createdAt %></li>
+      <% }) %>
+    </ul>
+  <% } %>
+</body>
+</html>

--- a/views/partials/header.ejs
+++ b/views/partials/header.ejs
@@ -1,0 +1,16 @@
+<header>
+  <h1><a href="/">Pink Boutique</a></h1>
+  <nav>
+    <% if (currentUser) { %>
+      <a href="/logout">Logout</a>
+      <a href="/orders">My Orders</a>
+      <% if (currentUser.isAdmin) { %>
+      <a href="/admin/products">Admin</a>
+      <% } %>
+    <% } else { %>
+      <a href="/login">Login</a>
+      <a href="/signup">Signup</a>
+    <% } %>
+    <a href="/cart">Cart (<%= (session.cart || []).length %>)</a>
+  </nav>
+</header>

--- a/views/product.ejs
+++ b/views/product.ejs
@@ -1,0 +1,17 @@
+<!DOCTYPE html>
+<html>
+<head>
+  <title><%= product.name %> - Pink Boutique</title>
+  <link rel="stylesheet" href="/style.css">
+</head>
+<body>
+  <%- include('partials/header'); %>
+  <h2><%= product.name %></h2>
+  <img src="<%= product.image %>" alt="<%= product.name %>" />
+  <p><%= product.description %></p>
+  <p>$<%= product.price %></p>
+  <form method="post" action="/cart/add/<%= product.id %>">
+    <button type="submit">Add to Cart</button>
+  </form>
+</body>
+</html>

--- a/views/product_form.ejs
+++ b/views/product_form.ejs
@@ -1,0 +1,19 @@
+<!DOCTYPE html>
+<html>
+<head>
+  <title>Edit Product</title>
+  <link rel="stylesheet" href="/style.css">
+</head>
+<body>
+  <%- include('partials/header'); %>
+  <h2><%= product.id ? 'Edit' : 'Add' %> Product</h2>
+  <form method="post" action="/admin/products/save">
+    <input type="hidden" name="id" value="<%= product.id || '' %>">
+    <input type="text" name="name" placeholder="Name" value="<%= product.name || '' %>" required>
+    <input type="text" name="description" placeholder="Description" value="<%= product.description || '' %>" required>
+    <input type="number" step="0.01" name="price" placeholder="Price" value="<%= product.price || '' %>" required>
+    <input type="text" name="image" placeholder="Image URL" value="<%= product.image || '' %>" required>
+    <button type="submit">Save</button>
+  </form>
+</body>
+</html>

--- a/views/products.ejs
+++ b/views/products.ejs
@@ -1,0 +1,21 @@
+<!DOCTYPE html>
+<html>
+<head>
+  <title>Products - Pink Boutique</title>
+  <link rel="stylesheet" href="/style.css">
+</head>
+<body>
+  <%- include('partials/header'); %>
+  <h2>Products</h2>
+  <section class="products">
+    <% products.forEach(p => { %>
+      <div class="product">
+        <img src="<%= p.image %>" alt="<%= p.name %>" />
+        <h3><%= p.name %></h3>
+        <p>$<%= p.price %></p>
+        <a href="/product/<%= p.id %>">View</a>
+      </div>
+    <% }) %>
+  </section>
+</body>
+</html>

--- a/views/signup.ejs
+++ b/views/signup.ejs
@@ -1,0 +1,17 @@
+<!DOCTYPE html>
+<html>
+<head>
+  <title>Signup - Pink Boutique</title>
+  <link rel="stylesheet" href="/style.css">
+</head>
+<body>
+  <%- include('partials/header'); %>
+  <h2>Signup</h2>
+  <% if (flash.error) { %><p class="error"><%= flash.error %></p><% } %>
+  <form method="post" action="/signup">
+    <input type="email" name="email" placeholder="Email" required>
+    <input type="password" name="password" placeholder="Password" required>
+    <button type="submit">Signup</button>
+  </form>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- add Node.js/Express app for an e-commerce demo
- include EJS views and pink theme styling
- stub out `auditLog()` for blockchain-based logging
- document setup in README

## Testing
- `npm test`
- `npm install` *(fails: 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_688855c0a4a48320b94390a4ad62e384